### PR TITLE
Fix error custom context path azure function

### DIFF
--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureAnnotatedMethodRouteBuilder.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureAnnotatedMethodRouteBuilder.java
@@ -58,11 +58,9 @@ class AzureAnnotatedMethodRouteBuilder extends AnnotatedMethodRouteBuilder {
 
     @Override
     protected UriRoute buildBeanRoute(String httpMethodName, HttpMethod httpMethod, String uri, BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
-        String cp = contextPathProvider.getContextPath();
-        if (cp == null) {
-            cp = "/api";
+        if (contextPathProvider.getContextPath() == null) {
+            uri = StringUtils.prependUri("/api", uri);
         }
-        uri = StringUtils.prependUri(cp, uri);
         return super.buildBeanRoute(httpMethodName, httpMethod, uri, beanDefinition, method);
     }
 }


### PR DESCRIPTION
Fix [#30](https://github.com/micronaut-projects/micronaut-azure/issues/30)

Micronaut Azure HTTP functions do not work if you define a micronaut.server.contextPath. When defined the context path is duplicated.